### PR TITLE
Optimizations

### DIFF
--- a/examples/rainbow.cr
+++ b/examples/rainbow.cr
@@ -4,10 +4,9 @@ canvas = StumpyPNG::Canvas.new(256, 256)
 
 (0...255).each do |x|
   (0...255).each do |y|
-    color = StumpyPNG::RGBA.from_rgb_n([x, y, 255], 8)
+    color = StumpyPNG::RGBA.from_rgb_n(x, y, 255, 8)
     canvas.set_pixel(x, y, color)
   end
 end
 
 StumpyPNG.write(canvas, "rainbow.png")
-

--- a/src/stumpy_png.cr
+++ b/src/stumpy_png.cr
@@ -16,10 +16,10 @@ module StumpyPNG
     datastream = Datastream.new
 
     ihdr_data = [] of UInt8
-    ihdr_data += Utils.uint32_to_bytes(canvas.width)
-    ihdr_data += Utils.uint32_to_bytes(canvas.height)
+    ihdr_data.concat Utils.uint32_to_bytes(canvas.width)
+    ihdr_data.concat Utils.uint32_to_bytes(canvas.height)
     # bit depth = 16 bit, color_type = rgba, compression = filter = interlacing = none
-    ihdr_data += [16_u8, 6_u8, 0_u8, 0_u8, 0_u8]
+    ihdr_data.concat({16_u8, 6_u8, 0_u8, 0_u8, 0_u8})
 
     datastream.chunks << Chunk.new("IHDR", ihdr_data)
 
@@ -28,7 +28,7 @@ module StumpyPNG
     canvas.each_column do |col|
       buffer.write_byte(0_u8) # filter = none
       col.each do |pixel|
-        [pixel.r, pixel.g, pixel.b, pixel.a].each do |value|
+        {pixel.r, pixel.g, pixel.b, pixel.a}.each do |value|
           Utils.uint16_to_bytes(value).each do |byte|
             buffer.write_byte(byte)
           end

--- a/src/stumpy_png/canvas.cr
+++ b/src/stumpy_png/canvas.cr
@@ -4,10 +4,10 @@ module StumpyPNG
   class Canvas
     getter width : Int32
     getter height : Int32
-    getter pixels : Array(RGBA)
+    getter pixels : Slice(RGBA)
 
     def initialize(@width, @height)
-      @pixels = Array.new(@width * @height, RGBA.new(0_u16, 0_u16, 0_u16, 0_u16))
+      @pixels = Slice.new(@width * @height, RGBA.new(0_u16, 0_u16, 0_u16, 0_u16))
     end
 
     def set_pixel(x, y, color)

--- a/src/stumpy_png/chunk.cr
+++ b/src/stumpy_png/chunk.cr
@@ -31,7 +31,7 @@ module StumpyPNG
     end
 
     def raw : Array(UInt8)
-      @type.chars.map { |c| c.ord.to_u8 } + @data + Utils.uint32_to_bytes(@crc)
+      @type.chars.map { |c| c.ord.to_u8 } + @data + Utils.uint32_to_bytes(@crc).to_a
     end
   end
 end

--- a/src/stumpy_png/datastream.cr
+++ b/src/stumpy_png/datastream.cr
@@ -36,8 +36,8 @@ module StumpyPNG
 
       @chunks.each do |chunk|
         # [chunk length][chunk raw = type, data, crc]
-        bytes += Utils.uint32_to_bytes(chunk.size)
-        bytes += chunk.raw
+        bytes.concat Utils.uint32_to_bytes(chunk.size)
+        bytes.concat chunk.raw
       end
 
       bytes

--- a/src/stumpy_png/rgba.cr
+++ b/src/stumpy_png/rgba.cr
@@ -1,11 +1,11 @@
 require "./utils"
 
 module StumpyPNG
-  class RGBA
-    property r : UInt16
-    property g : UInt16
-    property b : UInt16
-    property a : UInt16
+  struct RGBA
+    getter r : UInt16
+    getter g : UInt16
+    getter b : UInt16
+    getter a : UInt16
 
     def initialize(@r, @g, @b, @a)
     end
@@ -21,19 +21,16 @@ module StumpyPNG
       )
     end
 
-    def ==(other)
-      self.class == other.class &&
-      @r == other.r &&
-      @g == other.g &&
-      @b == other.b &&
-      @a == other.a
+    def self.from_rgba_n(values, n)
+      r, g, b, a = values
+      from_rgba_n(r, g, b, a, n)
     end
 
-    def self.from_rgba_n(values, n)
-      red   = Utils.scale_up(values[0], n)
-      green = Utils.scale_up(values[1], n)
-      blue  = Utils.scale_up(values[2], n)
-      alpha = Utils.scale_up(values[3], n)
+    def self.from_rgba_n(r, g, b, a, n)
+      red = Utils.scale_up(r, n)
+      green = Utils.scale_up(g, n)
+      blue = Utils.scale_up(b, n)
+      alpha = Utils.scale_up(a, n)
       RGBA.new(red, green, blue, alpha)
     end
 
@@ -49,9 +46,14 @@ module StumpyPNG
     end
 
     def self.from_rgb_n(values, n)
-      red   = Utils.scale_up(values[0], n)
-      green = Utils.scale_up(values[1], n)
-      blue  = Utils.scale_up(values[2], n)
+      r, g, b = values
+      from_rgb_n(r, g, b, n)
+    end
+
+    def self.from_rgb_n(r, g, b, n)
+      red = Utils.scale_up(r, n)
+      green = Utils.scale_up(g, n)
+      blue = Utils.scale_up(b, n)
       RGBA.new(red, green, blue, UInt16::MAX)
     end
 

--- a/src/stumpy_png/utils.cr
+++ b/src/stumpy_png/utils.cr
@@ -9,11 +9,11 @@ module StumpyPNG
     end
 
     def self.uint32_to_bytes(int)
-      [24, 16, 8, 0].map { |n| (int >> n & 0xff).to_u8 }
+      {24, 16, 8, 0}.map { |n| (int >> n & 0xff).to_u8 }
     end
 
     def self.uint16_to_bytes(int)
-      [8, 0].map { |n| (int >> n & 0xff).to_u8 }
+      {8, 0}.map { |n| (int >> n & 0xff).to_u8 }
     end
 
     def self.read_n_byte(file, n)
@@ -32,7 +32,7 @@ module StumpyPNG
       pa = (p - a).abs # distances to a, b, c
       pb = (p - b).abs
       pc = (p - c).abs
-      
+
       if pa <= pb && pa <= pc
         return a.to_u8
       elsif pb <= pc


### PR DESCRIPTION
Fixes #1 

All optimizations here are about avoiding extra heap allocations:

1. RBGA is made a struct for this reason
2. Instead of returning arrays in `uint32_to_bytes` methods, return tuples (I actually think retuning a StaticArray might be better, because then one can write it directly to an IO, but we can leave that for a later PR)
3. Instead of using `array += another_array`, which creates a new array with the contents of the original array and the other array, use `concat`

There are many more optimizations that could be done, but with this my program takes about 5 times less to write a 1920x1200 PNG. 

Other possible optimizations could be:
* Don't create intermediate chunks, but stream directly to the IO
* Deflate the content in one pass instead of writing it to a buffer first. I actually tried to do this but the specs fail, I don't know if there's a reason that this must be done like it's done right now.