### PR TITLE
Read optimizations. MemoryIO -> IO::Memory. Slice(UInt8) -> Bytes

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,9 +2,9 @@ version: 1.0
 shards:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: 0.3.4
+    version: 0.3.5
 
   stumpy_core:
     git: https://github.com/l3kn/stumpy_core.git
-    commit: ad801752a9be6aff29a4754497c0aa826b7acfb9
+    commit: 5ead919871579b164233a287fc6c519a29ffeb95
 

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,6 @@ dependencies:
 development_dependencies:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 0.3.1
+    version: ~> 0.3.5
 
 license: MIT

--- a/src/stumpy_png/chunk.cr
+++ b/src/stumpy_png/chunk.cr
@@ -3,11 +3,11 @@ require "./utils"
 module StumpyPNG
   class Chunk
     property type : String
-    property data : Slice(UInt8)
+    property data : Bytes
     property crc : UInt32
 
     # Parse chunk data **without** size.
-    def self.parse(slice : Slice(UInt8))
+    def self.parse(slice : Bytes)
       type = String.new slice[0, 4]
       crc = Utils.bytes_to_uint32(slice[slice.size - 4, 4])
       data = slice[4, slice.size - 8]
@@ -32,9 +32,9 @@ module StumpyPNG
       @data.size
     end
 
-    # Returns chunk data **with** size as a `Slice(UInt8)`.
-    def raw : Slice(UInt8)
-      io = MemoryIO.new
+    # Returns chunk data **with** size as a `Bytes`.
+    def raw : Bytes
+      io = IO::Memory.new
       write(io)
       io.to_slice
     end

--- a/src/stumpy_png/datastream.cr
+++ b/src/stumpy_png/datastream.cr
@@ -29,7 +29,7 @@ module StumpyPNG
           break
         end
 
-        chunk_data = Slice(UInt8).new(chunk_length + 4 + 4)
+        chunk_data = Bytes.new(chunk_length + 4 + 4)
         io.read_fully(chunk_data)
 
         chunks << Chunk.parse(chunk_data)
@@ -38,8 +38,8 @@ module StumpyPNG
       Datastream.new chunks
     end
 
-    def raw : Slice(UInt8)
-      io = MemoryIO.new
+    def raw : Bytes
+      io = IO::Memory.new
       write(io)
       io.to_slice
     end

--- a/src/stumpy_png/filters.cr
+++ b/src/stumpy_png/filters.cr
@@ -1,28 +1,64 @@
 module StumpyPNG
   module Filter
-    def self.apply(scanline : Slice(UInt8), prior_scanline : Slice(UInt8), bpp, filter)
-      # Filter = NONE
-      return scanline if filter == 0
-
-      decoded = Slice(UInt8).new(scanline.size)
-
-      scanline.each_with_index do |byte, index|
-        prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
-        above = prior_scanline.empty? ? 0 : prior_scanline[index]
-        upper_left = (prior_scanline.empty? || (index - bpp) < 0) ? 0 : prior_scanline[index - bpp]
-
-        case filter
-        when 1 # Sub
+    def self.apply(scanline : Bytes, prior_scanline : Bytes, decoded : Bytes, bpp, filter) : Bytes
+      case filter
+      when 0 # None
+        return scanline
+      when 1 # Sub
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
           decoded[index] = byte + prior
-        when 2 # Up
-          decoded[index] = byte + above
-        when 3 # Average
-          decoded[index] = byte + ((prior.to_f + above.to_f) / 2).floor.to_u8
-        when 4 # Paeth
-          decoded[index] = byte + Utils.paeth_predictor(prior, above, upper_left)
-        else
-          raise "Unknown filter type #{filter}"
         end
+      when 2 # Up
+        scanline.each_with_index do |byte, index|
+          above = prior_scanline[index]
+          decoded[index] = byte + above
+        end
+      when 3 # Average
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
+          above = prior_scanline[index]
+          decoded[index] = byte + ((prior.to_f + above.to_f) / 2).floor.to_u8
+        end
+      when 4 # Paeth
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
+          above = prior_scanline[index]
+          upper_left = (index - bpp) < 0 ? 0 : prior_scanline[index - bpp]
+          decoded[index] = byte + Utils.paeth_predictor(prior, above, upper_left)
+        end
+      else
+        raise "Unknown filter type #{filter}"
+      end
+
+      decoded
+    end
+
+    def self.apply(scanline : Bytes, prior_scanline : Nil, decoded : Bytes, bpp, filter) : Bytes
+      case filter
+      when 0 # None
+        return scanline
+      when 1 # Sub
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
+          decoded[index] = byte + prior
+        end
+      when 2 # Up
+        scanline.each_with_index do |byte, index|
+          decoded[index] = byte
+        end
+      when 3 # Average
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
+          decoded[index] = byte + (prior.to_f / 2).floor.to_u8
+        end
+      when 4 # Paeth
+        scanline.each_with_index do |byte, index|
+          prior = (index - bpp) < 0 ? 0 : decoded[index - bpp]
+          decoded[index] = byte + Utils.paeth_predictor(prior, 0, 0)
+        end
+      else
+        raise "Unknown filter type #{filter}"
       end
 
       decoded

--- a/src/stumpy_png/utils.cr
+++ b/src/stumpy_png/utils.cr
@@ -17,7 +17,7 @@ module StumpyPNG
     end
 
     def self.read_n_byte(file, n)
-      slice = Slice(UInt8).new(n)
+      slice = Bytes.new(n)
       file.read_fully(slice)
       slice.to_a
     end
@@ -42,10 +42,10 @@ module StumpyPNG
       end
     end
 
-    class NBitEnumerable
+    struct NBitEnumerable
       include Enumerable(UInt16)
 
-      property values : Slice(UInt8)
+      property values : Bytes
       property size
 
       def initialize(@values, @size = 8_u8)


### PR DESCRIPTION
The biggest optimization is not using `each_slice` in `ColorTypes.decode`. `each_slice` returns an array for each n consecutive elements, so that was allocating way too many arrays.

Then I also moved the `case` expression of Filter.apply outside the loop, so that check has to be done one per scanline. I initially thought this isn't right, but other implementations (like oily_png) does that too. I guess there are many more places where this "moving outside the loop" can be done.

Then I also tried to reduce allocations in `to_canvas_none` by allocating just two slices and swapping them on every iteration, instead of allocating one per iteration.

Finally, I updated the code to Crystal 0.20.0 and did some other renames so code is shorter.

The result is not as good as I'd like, but since I don't know the underlying algorithms there isn't much I can do for now. I'm sure there's still a lot of room for optimizations. For example, while `NBitEnumerable` looks nice, I'm sure that not using that and computing pixel values in a loop must be faster (because now in color types we can only iterate one by one, accumulate into a slice, etc.). Probably having specialized code for each bit depth would be optimal, but this is just a guess.

Based on #7...

Before:

```
Read: 347.97ms (59.37%)
Transform: 16.57ms (2.83%)
Write: 221.58ms (37.8%)
Total: 586.12ms
```

After:

```
Read: 179.76ms (40.04%)
Transform: 17.27ms (3.85%)
Write: 251.97ms (56.12%)
Total: 449.0ms
```