### PR TITLE
Optimize StumpyPNG.write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.crystal
 /.shards
 /libs
+/lib
 /tmp

--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   stumpy_core:
     git: https://github.com/l3kn/stumpy_core.git
-    commit: 1d901c36f695ce11f88524d604f0e2e40f2267af
+    commit: 5cb0a88a17c78a30c7041b96a7b08202a32d657e
 

--- a/spec/png_suite_spec.cr
+++ b/spec/png_suite_spec.cr
@@ -13,7 +13,7 @@ module StumpyPNG
         # system "convert -depth 8 -compress none -gamma 0.999999 #{image} #{reference_path}"
 
         reference = File.read(reference_path).bytes
-        rgba = canvas.pixels.map(&.to_rgba8).map(&.to_a).flatten
+        rgba = canvas.pixels.map(&.to_rgba).map(&.to_a).flatten
 
         assert_equal reference, rgba
       end


### PR DESCRIPTION
The main optimization is to avoid IO::Memory and use a fixed slice and write into that, which is a bit faster.

Before:

```
Read: 151.55ms (37.56%)
Transform: 17.8ms (4.41%)
Write: 234.15ms (58.03%)
Total: 403.5ms
```

After:

```
Read: 148.56ms (42.63%)
Transform: 20.02ms (5.74%)
Write: 179.88ms (51.62%)
Total: 348.46ms
```

As a side note, I noted memory consumption is pretty high, mostly because a lot of buffers are needed that hold all of the data in memory, sometimes multiple times (for example data is read, then analyzed in a different buffer). Is there maybe a different way to do it without preloading everything? For example the Python version only uses 17MB while Crystal uses 53MB or so. In any case, that's an optimization that can be done later, and speed is usually more important.

Another question is whether the whole data needs to be written and then deflated/inflated instead of being done lazily... I see some crc32 checks so maybe there's no way around it, or maybe one could use an IO::MultiWriter to write the output and at the same time compute a crc, but I don't know (I think right now there's no way to do that in the standard library)