### PR TITLE
Update code to work with Crystal 0.21.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: stumpy_png
-version: 4.1.0
+version: 4.1.1
 
 authors:
   - Leon Rische <hello@l3kn.de>

--- a/src/stumpy_png.cr
+++ b/src/stumpy_png.cr
@@ -3,6 +3,7 @@ require "stumpy_core"
 require "./stumpy_png/png"
 require "./stumpy_png/crc_io"
 require "io/multi_writer"
+require "crc32"
 
 module StumpyPNG
   include StumpyCore
@@ -71,7 +72,7 @@ module StumpyPNG
       multi << "IDAT"
       crc_io.size = 0
 
-      Zlib::Deflate.new(multi) do |deflate|
+      Zlib::Writer.open(multi) do |deflate|
         case color_type
         when :rgb_alpha; write_rgb_alpha(canvas, deflate, bit_depth)
         when :rgb; write_rgb(canvas, deflate, bit_depth)
@@ -89,7 +90,7 @@ module StumpyPNG
       # Write the IEND chunk
       file.write_bytes(0_u32, IO::ByteFormat::BigEndian)
       multi << "IEND"
-      multi.write_bytes(Zlib.crc32("IEND").to_u32, IO::ByteFormat::BigEndian)
+      multi.write_bytes(CRC32.checksum("IEND"), IO::ByteFormat::BigEndian)
     end
   end
 

--- a/src/stumpy_png/chunk.cr
+++ b/src/stumpy_png/chunk.cr
@@ -1,5 +1,7 @@
 require "./utils"
 
+require "crc32"
+
 module StumpyPNG
   class Chunk
     property type : String
@@ -12,7 +14,7 @@ module StumpyPNG
       crc = Utils.bytes_to_uint32(slice[slice.size - 4, 4])
       data = slice[4, slice.size - 8]
 
-      expected_crc = Zlib.crc32(slice[0, slice.size - 4])
+      expected_crc = CRC32.checksum(slice[0, slice.size - 4])
       raise "Incorrect checksum" if crc != expected_crc
 
       Chunk.new(type, data, crc)
@@ -22,9 +24,9 @@ module StumpyPNG
       if crc
         @crc = crc
       elsif data.empty?
-        @crc = Zlib.crc32(type).to_u32
+        @crc = CRC32.checksum(type)
       else
-        @crc = Zlib.crc32(data, Zlib.crc32(type)).to_u32
+        @crc = CRC32.update(data, CRC32.checksum(type))
       end
     end
 

--- a/src/stumpy_png/crc_io.cr
+++ b/src/stumpy_png/crc_io.cr
@@ -1,13 +1,15 @@
 require "zlib"
 
+require "crc32"
+
 class CrcIO
   include IO
 
-  getter crc : UInt64
+  getter crc : UInt32
   property size
 
   def initialize
-    @crc = 0_u64
+    @crc = 0_u32
     @size = 0
   end
 
@@ -16,12 +18,12 @@ class CrcIO
   end
 
   def write(slice : Slice(UInt8))
-    @crc = Zlib.crc32(slice, @crc)
+    @crc = CRC32.update(slice, @crc)
     @size += slice.size
   end
 
   def reset
-    @crc = 0_u64
+    @crc = 0_u32
   end
 
 end

--- a/src/stumpy_png/png.cr
+++ b/src/stumpy_png/png.cr
@@ -52,7 +52,7 @@ module StumpyPNG
       # Reset buffer position
       @idat_buffer.pos = 0
 
-      contents = Zlib::Inflate.new(@idat_buffer) do |inflate|
+      contents = Zlib::Reader.open(@idat_buffer) do |inflate|
         io = IO::Memory.new
         IO.copy(inflate, io)
         @data = io.to_slice


### PR DESCRIPTION
Crystal 0.21.0 renamed some modules and types in the standard library. This PR changes the names so that stumpy_png compiles under Crystal 0.21.0.

@l3kn 